### PR TITLE
Adds ping checker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,9 @@ Out of the box, the following checkers are available.
 | web    | Check web service state   | - **url**: The webservice URL                                                                      |
 |        |                           | - **statuses**: (optional, default=None) A collection of acceptable status codes (aside from 200). |
 +--------+---------------------------+----------------------------------------------------------------------------------------------------+
+| ping   | Ping external hosts       | - **host**: Hostname to ping.                                                                      |
+|        |                           |                                                                                                    |
++--------+---------------------------+----------------------------------------------------------------------------------------------------+
 
 Future versions of Preflyt will add additional default checkers while allowing third parties to ship their own.
 

--- a/preflyt/checkers/network.py
+++ b/preflyt/checkers/network.py
@@ -1,6 +1,6 @@
 """Check machines with ping."""
 
-from subprocess import run, PIPE
+from subprocess import call, DEVNULL
 import platform
 
 from preflyt.base import BaseChecker
@@ -28,7 +28,7 @@ class PingChecker(BaseChecker):
 
 
     def check(self):
-        response = run(self._command, shell=True, stdout=PIPE, stderr=PIPE)
-        if response.returncode == 0:
+        response = call(self._command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+        if response == 0:
             return True, "{} is pingable".format(self._host)
         return False, "Cannot reach {}".format(self._host)

--- a/preflyt/checkers/network.py
+++ b/preflyt/checkers/network.py
@@ -1,0 +1,34 @@
+"""Check machines with ping."""
+
+from subprocess import run, PIPE
+import platform
+
+from preflyt.base import BaseChecker
+
+
+class PingChecker(BaseChecker):
+    """Verify that a machine responds to ping requests."""
+
+    checker_name = "ping"
+
+    def __init__(self, host):
+        """Initialize the checker.
+
+        :param host: the IP or hostname of the host to ping
+
+        """
+        if platform.system().lower() == 'windows':
+            switch = "n"
+        else:
+            switch = "c"
+
+        self._switch = switch
+        self._host = host
+        self._command = "ping -{} 1 {}".format(switch, host)
+
+
+    def check(self):
+        response = run(self._command, shell=True, stdout=PIPE, stderr=PIPE)
+        if response.returncode == 0:
+            return True, "{} is pingable".format(self._host)
+        return False, "Cannot reach {}".format(self._host)

--- a/preflyt/checkers/network.py
+++ b/preflyt/checkers/network.py
@@ -1,6 +1,6 @@
 """Check machines with ping."""
 
-from subprocess import call, DEVNULL
+import subprocess
 import platform
 
 from preflyt.base import BaseChecker
@@ -28,7 +28,7 @@ class PingChecker(BaseChecker):
 
 
     def check(self):
-        response = call(self._command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+        response = subprocess.call(self._command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         if response == 0:
             return True, "{} is pingable".format(self._host)
         return False, "Cannot reach {}".format(self._host)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -36,17 +36,18 @@ def test_ping_other_switch(system):
     eq_(ping._host, LOCALHOST)
     eq_(ping._switch, 'c')
 
-def test_ping_localhost():
+@patch("subprocess.call", return_value=0)
+def test_ping_localhost(call):
     ping = PingChecker(LOCALHOST)
     eq_(ping._host, LOCALHOST)
     result, message = ping.check()
     ok_(result)
     ok_('pingable' in message)
 
-def test_ping_invalid_host():
+@patch("subprocess.call", return_value=1)
+def test_ping_invalid_host(call):
     ping = PingChecker(INVALID_HOST)
     eq_(ping._host, INVALID_HOST)
     result, message = ping.check()
     ok_(not result)
     ok_("Cannot reach" in message)
-    

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,52 @@
+"""Test the filesystem checker"""
+
+# pylint: disable=missing-docstring,protected-access
+
+from unittest.mock import patch
+
+from nose.tools import ok_, eq_
+
+from preflyt.checkers.network import PingChecker
+
+
+LOCALHOST = '127.0.0.1'
+INVALID_HOST = '333.333.666.666'
+
+def test_ping_init():
+    ping = PingChecker(LOCALHOST)
+    eq_(PingChecker.checker_name, "ping")
+    eq_(ping._host, LOCALHOST)
+    ok_(ping._switch)
+
+@patch("platform.system", return_value='Windows')
+def test_ping_windows_switch(system):
+    ping = PingChecker(LOCALHOST)
+    eq_(ping._host, LOCALHOST)
+    eq_(ping._switch, 'n')
+
+@patch("platform.system", return_value='Linux')
+def test_ping_linux_switch(system):
+    ping = PingChecker(LOCALHOST)
+    eq_(ping._host, LOCALHOST)
+    eq_(ping._switch, 'c')
+
+@patch("platform.system", return_value='MatrixOS')
+def test_ping_other_switch(system):
+    ping = PingChecker(LOCALHOST)
+    eq_(ping._host, LOCALHOST)
+    eq_(ping._switch, 'c')
+
+def test_ping_localhost():
+    ping = PingChecker(LOCALHOST)
+    eq_(ping._host, LOCALHOST)
+    result, message = ping.check()
+    ok_(result)
+    ok_('pingable' in message)
+
+def test_ping_invalid_host():
+    ping = PingChecker(INVALID_HOST)
+    eq_(ping._host, INVALID_HOST)
+    result, message = ping.check()
+    ok_(not result)
+    ok_("Cannot reach" in message)
+    


### PR DESCRIPTION
Creates a network module to hold a **ping** checker and future checkers of its ilk. 

This is a weird one due to needing the underlying system (in this case, via `subprocess.run`), but the switch toggle seems to suffice for cross-platform compatibility. 